### PR TITLE
Fix Playback of sequential Single timings

### DIFF
--- a/src/PipeScore/Playback/index.ts
+++ b/src/PipeScore/Playback/index.ts
@@ -141,11 +141,13 @@ export class PlaybackSecondTiming {
   start: PlaybackIndex;
   middle: PlaybackIndex;
   end: PlaybackIndex;
+  isSingleTiming:boolean;
 
-  constructor(start: PlaybackIndex, middle: PlaybackIndex, end: PlaybackIndex) {
+  constructor(start: PlaybackIndex, middle: PlaybackIndex, end: PlaybackIndex,isSingleTiming:boolean=false) {
     this.start = start;
     this.middle = middle;
     this.end = end;
+    this.isSingleTiming = isSingleTiming;
   }
 
   in(index: PlaybackIndex) {

--- a/src/PipeScore/Score/impl.ts
+++ b/src/PipeScore/Score/impl.ts
@@ -442,6 +442,32 @@ export class Score extends IScore {
   }
 
   playbackTimings(elements: PlaybackMeasure[]) {
-    return removeNulls(this._timings.map((st) => st.play(elements)));
+    // return removeNulls(this._timings.map((st) => st.play(elements)));
+    let tempTimings = removeNulls(this._timings.map((st) => st.play(elements)));
+    let timings=[];
+    let firsTiming =null;
+    // Convert 2 Single PlaybackSecondTiming into a single PlaybackSecondTiming
+    for (let i = 0; i < tempTimings.length; i++) {
+      if(tempTimings[i].isSingleTiming)
+      {
+        if(firsTiming==null)
+          firsTiming = tempTimings[i];
+        else
+        {
+          // adjust middle and end index 
+          firsTiming.middle = firsTiming.end;
+          firsTiming.end=tempTimings[i].end
+          timings.push(firsTiming);
+          firsTiming = null;
+        }
+      }
+      else
+      {
+        timings.push(tempTimings[i]);
+        firsTiming = null;
+      }
+      
+    }
+    return timings;
   }
 }

--- a/src/PipeScore/Timing/impl.ts
+++ b/src/PipeScore/Timing/impl.ts
@@ -367,9 +367,39 @@ export class SingleTiming extends Timing {
       },
     ];
   }
+  play(measures: PlaybackMeasure[]): PlaybackSecondTiming | null {
+    let startIndex: PlaybackIndex | null = null;
+    let middleIndex:PlaybackIndex = new PlaybackIndex(-1, 0);
+    let endIndex: PlaybackIndex | null = null;
 
-  play() {
-    // TODO : support single timings ... ?
-    return null;
+    for (let measureIndex = 0; measureIndex < measures.length; measureIndex++) {
+      const parts = measures[measureIndex].parts;
+      for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+        const part = parts[partIndex];
+        for (let itemIndex = 0; itemIndex < part.length; itemIndex++) {
+          const item = part[itemIndex];
+          if (item instanceof PlaybackObject) {
+            if (item.type === 'object-start' && item.id === this.start) {
+              const timeToItem = measures[measureIndex].timeTo(partIndex, itemIndex);
+              startIndex = new PlaybackIndex(measureIndex, timeToItem);
+            } else if (item.type === 'object-end' && item.id === this.end) {
+              const timeToItem = measures[measureIndex].timeToAfter(
+                partIndex,
+                itemIndex
+              );
+              endIndex = new PlaybackIndex(measureIndex, timeToItem);
+            }
+          }
+        }
+      }
+    }
+
+    if (startIndex === null || middleIndex === null || endIndex === null) {
+      console.error("Didn't find playback measure", this);
+      return null;
+    }
+
+    return new PlaybackSecondTiming(startIndex, middleIndex, endIndex, true);
   }
+
 }


### PR DESCRIPTION
Converts 2 sequential single timings to a Second timing this fixes most playbacks.

This is not fixing Single timing e.g. 2 of 2 . It only works for sequential singles.