### PR TITLE
Feature combine scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ tsserver.log
 __pycache__
 
 .DS_Store
+.vscode
+*.aup3-shm
+*.aup3-wal
+*.aup3

--- a/src/Scores/scores.ts
+++ b/src/Scores/scores.ts
@@ -201,13 +201,7 @@ class ScoresList {
       setName(scores[0], `(Combined)${getName(scores[0])}`);
       for (let i = 1; i < scores.length; i++) {
         setName(scores[0], `${getName(scores[0])} - ${getName(scores[i])}`);
-        setComposer(scores[0], `${getComposer(scores[0])} - ${getComposer(scores[i])}`);
-        for (const stave of scores[i].tunes[0].staves) {
-          scores[0].tunes[0].staves.push(stave);
-        }
-        for (const secondTiming of scores[i].secondTimings) {
-          scores[0].secondTimings.push(secondTiming);
-        }
+        scores[0].tunes.push(scores[i].tunes[0]);
       }
       await db.ref(`scores/${userId}/scores`).add(scores[0]);
 
@@ -250,7 +244,7 @@ class ScoresList {
         ),
         m('tr', [
           m(
-            'button.edit',
+            'button.combine',
             {
               onclick: () => this.combineScores(),
               disabled: this.selected.length < 2,

--- a/src/Scores/scores.ts
+++ b/src/Scores/scores.ts
@@ -69,31 +69,6 @@ function setName(
     s.tunes[0].name = name;
   }
 }
-function getComposer(
-  score: Document | ScoreRef | SavedScore 
-) {
-  const defaultName = 'Composer';
-  const sscore = score as SavedScore;
-  const composer = sscore.tunes?.[0]?.composer;
-
-  if (typeof composer === 'string') {
-    return composer || defaultName;
-  }
-
-  return composer.text || defaultName;
-}
-
-function setComposer(
-  score: Document | ScoreRef | SavedScore ,
-  composer: string
-) {
-  const s = score as SavedScore | DeprecatedSavedScore;
-  if (scoreHasStavesNotTunes(s)) {
-    s.name = composer;
-  } else if (s.tunes[0]) {
-    s.tunes[0].composer = composer;
-  }
-}
 class ScoresList {
   loading = true;
   scores: ScoreRef[] = [];
@@ -202,6 +177,10 @@ class ScoresList {
       for (let i = 1; i < scores.length; i++) {
         setName(scores[0], `${getName(scores[0])} - ${getName(scores[i])}`);
         scores[0].tunes.push(scores[i].tunes[0]);
+        for(const secondTiming of scores[i].secondTimings)
+        {
+          scores[0].secondTimings.push(secondTiming);
+        }
       }
       await db.ref(`scores/${userId}/scores`).add(scores[0]);
 

--- a/src/Scores/scores.ts
+++ b/src/Scores/scores.ts
@@ -244,12 +244,15 @@ class ScoresList {
         ),
         m('tr', [
           m(
-            'button.combine',
-            {
-              onclick: () => this.combineScores(),
-              disabled: this.selected.length < 2,
-            },
-            'Combine Scores'
+            'td',
+            m(
+              'button.combine',
+              {
+                onclick: () => this.combineScores(),
+                disabled: this.selected.length < 2,
+              },
+              'Combine Scores'
+            ),
           ),
         ]),
       ]),

--- a/src/Scores/scores.ts
+++ b/src/Scores/scores.ts
@@ -36,11 +36,13 @@ const auth = new Auth({ apiKey: apiToken });
 
 const db = new Database({ projectId: 'pipe-score', auth });
 
-type ScoreRef = { path: string };
+type ScoreRef = { name: string; path: string };
 
 type FileInput = HTMLInputElement & { files: FileList };
 
-function getName(score: Document | ScoreRef | SavedScore | DeprecatedSavedScore) {
+function getName(
+  score: Document | ScoreRef | SavedScore | DeprecatedSavedScore
+) {
   const defaultName = 'Empty Score';
   if ((score as DeprecatedSavedScore).name) {
     return (score as DeprecatedSavedScore).name || defaultName;
@@ -67,10 +69,35 @@ function setName(
     s.tunes[0].name = name;
   }
 }
+function getComposer(
+  score: Document | ScoreRef | SavedScore 
+) {
+  const defaultName = 'Composer';
+  const sscore = score as SavedScore;
+  const composer = sscore.tunes?.[0]?.composer;
 
+  if (typeof composer === 'string') {
+    return composer || defaultName;
+  }
+
+  return composer.text || defaultName;
+}
+
+function setComposer(
+  score: Document | ScoreRef | SavedScore ,
+  composer: string
+) {
+  const s = score as SavedScore | DeprecatedSavedScore;
+  if (scoreHasStavesNotTunes(s)) {
+    s.name = composer;
+  } else if (s.tunes[0]) {
+    s.tunes[0].composer = composer;
+  }
+}
 class ScoresList {
   loading = true;
   scores: ScoreRef[] = [];
+  selected: ScoreRef[] = [];
 
   oninit() {
     onUserChange(auth, (user) => {
@@ -151,7 +178,46 @@ class ScoresList {
       this.refreshScores();
     }
   }
+  async updateSelection(scoreRef: ScoreRef, checked: boolean) {
+    if (checked) {
+      this.selected.push(scoreRef);
+    } else {
+      let index = this.selected.indexOf(scoreRef);
+      if (index > -1) {
+        this.selected.splice(index, 1);
+      }
+    }
+    m.redraw();
+  }
+  async combineScores() {
+    this.loading = true;
+    try {
+      const scores: SavedScore[] = [];
+      for (const score of this.selected) {
+        scores.push(
+          (await db.ref(`scores${score.path}`).get()) as unknown as SavedScore
+        );
+      }
+      setName(scores[0], `(Combined)${getName(scores[0])}`);
+      for (let i = 1; i < scores.length; i++) {
+        setName(scores[0], `${getName(scores[0])} - ${getName(scores[i])}`);
+        setComposer(scores[0], `${getComposer(scores[0])} - ${getComposer(scores[i])}`);
+        for (const stave of scores[i].tunes[0].staves) {
+          scores[0].tunes[0].staves.push(stave);
+        }
+        for (const secondTiming of scores[i].secondTimings) {
+          scores[0].secondTimings.push(secondTiming);
+        }
+      }
+      await db.ref(`scores/${userId}/scores`).add(scores[0]);
 
+    } catch (e) {
+      console.log(e);
+      alert(`Error combining scores: ${(e as Error).name}`);
+    }
+    this.selected = [];
+    this.refreshScores();
+  }
   async refreshScores() {
     const collection = await db.ref(`scores/${userId}/scores`).list({
       pageSize: 1000,
@@ -175,6 +241,24 @@ class ScoresList {
       `/pipescore${score.path.replace('/scores/', '/')}`;
 
     return [
+      m('p', 'Selected Scores:'),
+      m('table', [
+        ...this.selected.map((score) =>
+          m('tr', [
+            m('td.td-name', m('a', { href: path(score) }, getName(score))),
+          ])
+        ),
+        m('tr', [
+          m(
+            'button.edit',
+            {
+              onclick: () => this.combineScores(),
+              disabled: this.selected.length < 2,
+            },
+            'Combine Scores'
+          ),
+        ]),
+      ]),
       m('p', 'Scores:'),
       this.scores.length === 0 ? m('p', 'You have no scores.') : null,
       m('table', [
@@ -191,7 +275,11 @@ class ScoresList {
             ),
             m(
               'td',
-              m('button.rename', { onclick: () => this.rename(score) }, 'Rename')
+              m(
+                'button.rename',
+                { onclick: () => this.rename(score) },
+                'Rename'
+              )
             ),
             m(
               'td',
@@ -203,7 +291,22 @@ class ScoresList {
             ),
             m(
               'td',
-              m('button.delete', { onclick: () => this.delete(score) }, 'Delete')
+              m(
+                'button.delete',
+                { onclick: () => this.delete(score) },
+                'Delete'
+              )
+            ),
+            m(
+              'td',
+              m('input', {
+                type: 'checkbox',
+                onchange: (e: InputEvent) =>
+                  this.updateSelection(
+                    score,
+                    Boolean((e.target as HTMLInputElement).checked)
+                  ),
+              })
             ),
           ])
         ),


### PR DESCRIPTION
Adds Score selection checkbox on each score in list. 
Once 2 scores are selected the Combine Scores button is enabled.
The scores selected are then combined into one score. Combines name of each score into first score, adds tunes and secondTimings from subsequent scores to first score. Then saves score under new name prefixed with "(Combined)"
Order of selection determines order of scores combined.

![image](https://github.com/user-attachments/assets/62719434-8299-4e91-be4a-02407e6999b8)

results
![image](https://github.com/user-attachments/assets/b942cb29-0af6-47c9-a8be-ba4ae53d088f)
